### PR TITLE
Remove REPO_OWNER variable from Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,8 +30,7 @@ BUNDLE_METADATA_OPTS ?= $(BUNDLE_CHANNELS) $(BUNDLE_DEFAULT_CHANNEL)
 # For example, running 'make bundle-build bundle-push catalog-build catalog-push' will build and push both
 # oran.openshift.io/oran-hwmgr-plugin-test-bundle:$VERSION and oran.openshift.io/oran-hwmgr-plugin-test-catalog:$VERSION.
 IMAGE_NAME ?= oran-hwmgr-plugin-test
-REPO_OWNER ?= openshift-kni
-IMAGE_TAG_BASE ?= quay.io/$(REPO_OWNER)/$(IMAGE_NAME)
+IMAGE_TAG_BASE ?= quay.io/openshift-kni/$(IMAGE_NAME)
 
 # BUNDLE_IMG defines the image:tag used for the bundle.
 # You can use it as an arg. (E.g make bundle-build BUNDLE_IMG=<some-registry>/<project-name-bundle>:<tag>)

--- a/README.md
+++ b/README.md
@@ -39,8 +39,8 @@ To run the Test Plugin as a standalone without the O-Cloud Manager, the CRDs can
 The Test Plugin can be deployed to your cluster by first building the image and then running the `deploy` make target:
 
 ```console
-$ make REPO_OWNER=$USER VERSION=latest docker-build docker-push
-$ make REPO_OWNER=$USER VERSION=latest deploy
+$ make IMAGE_TAG_BASE=quay.io/$USER/oran-hwmgr-plugin-test VERSION=latest docker-build docker-push
+$ make IMAGE_TAG_BASE=quay.io/$USER/oran-hwmgr-plugin-test VERSION=latest deploy
 ```
 
 To watch the Test Plugin logs, run the following command:


### PR DESCRIPTION
REPO_OWNER is used in the CI, so this update drops it from the Makefile to avoid collisions.